### PR TITLE
Adding payment profile should return object #3960

### DIFF
--- a/transaction.py
+++ b/transaction.py
@@ -242,6 +242,4 @@ class AddPaymentProfile:
         #
         # In other words, each profile is maintained as a separate profile
         # on beanstream
-        self.create_profile(result['customerCode'])
-
-        return 'end'
+        return self.create_profile(result['customerCode'])


### PR DESCRIPTION
Adding a payment_profile in beanstream should return an object of profile
not just the 'end' string.
